### PR TITLE
Fix/dependency chain

### DIFF
--- a/src/examples/happy/depend-on-dependencies-hub-bis.js
+++ b/src/examples/happy/depend-on-dependencies-hub-bis.js
@@ -1,0 +1,7 @@
+export default {
+  depend: ["DependOnDependenciesHub"],
+
+  create: () => ({
+    dependOn: "hub",
+  }),
+}

--- a/src/examples/happy/depend-on-dependencies-hub.js
+++ b/src/examples/happy/depend-on-dependencies-hub.js
@@ -1,0 +1,7 @@
+export default {
+  depend: ["DependOnPlain"],
+
+  create: () => ({
+    dependOn: "hub",
+  }),
+}

--- a/src/pluginus.test.js
+++ b/src/pluginus.test.js
@@ -23,7 +23,15 @@ test("Happy", async t => {
 
   t.deepEquals(
     Object.keys(plugins).sort(),
-    ["DependOnPlain", "ExplicitName", "Object", "Plain", "PromisePlugin"],
+    [
+      "DependOnDependenciesHub",
+      "DependOnDependenciesHubBis",
+      "DependOnPlain",
+      "ExplicitName",
+      "Object",
+      "Plain",
+      "PromisePlugin",
+    ],
     'given [pluginus called with invalid values in "source" param] should [sanitize and load only valid]'
   )
 


### PR DESCRIPTION
I found elusive dependency errors in the past, but it was not until today that I understood the origin. 

Due to the sorting algorithm, when a fair number of plugins is used and when one plugin depend only on another that depends on something with several dependencies ... sorting is wrong and an exception is raised. 

A quick search on google on this kind of problem points to [TSort](https://en.wikipedia.org/wiki/Topological_sorting) as a typical solution ... which this PR implements. 

Let me know what you think.

Also, while I think this works on previously working (simple) dependency chains, this may be considered a breaking change.